### PR TITLE
Feat: Clone Existing Resume

### DIFF
--- a/src/resume/resume.routes.ts
+++ b/src/resume/resume.routes.ts
@@ -22,6 +22,7 @@ import { Router } from 'express';
 import {
   getResume,
   newResume,
+  newResumeCopy,
   updateEEPCP,
   updateTemplate,
 } from './resume.controller';
@@ -45,7 +46,9 @@ import { templateSpacingValidation } from './validators/template/spacing.validat
 
 const router = Router();
 
-router.post('/', newResume);
+router.get('/new', newResume);
+
+router.get('/new/:id', newResumeCopy);
 
 router.get('/:id', getResume);
 


### PR DESCRIPTION
## Changelog 
+ Clone Existing Resume by providing existing Resume ID (Works within the profile).
+ Route for Cloning existing Resume is GET `/resume/new/:id`.
+ Change REST route of creating Resume. (POST `/resume/` ->  GET `/resume/new`).

Signed-off-by: Himanshu Garg <garg_himanshu@outlook.com>